### PR TITLE
Add ee and eu languages. Wider dependency support.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-python-Levenshtein~=0.25.0
-statsmodels~=0.14.1
+Levenshtein >= 0.12.0
+statsmodels >= 0.12.1

--- a/wuggy/generators/wuggygenerator.py
+++ b/wuggy/generators/wuggygenerator.py
@@ -52,6 +52,7 @@ class WuggyGenerator():
         self.bigramchain = None
         self.bigramchains = {}
         self.supported_official_language_plugin_names = [
+            "orthographic_basque",
             "orthographic_dutch",
             "orthographic_english",
             "orthographic_french",
@@ -62,6 +63,7 @@ class WuggyGenerator():
             "orthographic_serbian_latin",
             "orthographic_spanish",
             "orthographic_vietnamese",
+            "orthographic_estonian",
             "phonetic_english_celex",
             "phonetic_english_cmu",
             "phonetic_french",


### PR DESCRIPTION
- Add ee and eu languages.
- Use previously specified dependency versions as minimum. No known or anticipated breakage thereafter.